### PR TITLE
Added rate limiting to prevent submitting requests to the Nexmo APIs too quickly

### DIFF
--- a/src/RateLimitSubscriber.php
+++ b/src/RateLimitSubscriber.php
@@ -1,0 +1,83 @@
+<?php
+namespace Nexmo;
+use GuzzleHttp\Event\BeforeEvent;
+use GuzzleHttp\Event\CompleteEvent;
+use GuzzleHttp\Event\SubscriberInterface;
+
+class RateLimitSubscriber implements SubscriberInterface
+{
+    /**
+     * @param array $time
+     * Rate limit for the SMS and Voice API is on a per-LVN/shortcode basis, so we record durations in an array with the LVN as the key.
+     * For maximum throughput messages should be sent from different LVNs in an interleaved patter, e.g., 1, 2, 3, 1, 2, 3 instead of 1, 1, 2, 2, 3, 3
+     * (or better, send from each LVN in parallel, concurrent threads).
+     */
+    private static $time = [];
+    private static $counter = [];
+
+    /**
+     * @param float $max_requests_per_sec
+     * Max number of requests per second. Nexmo's most restrictive API is the SMS API for US/Canada -> US/Canada routing at 1/sec, let's be safe and use that as default.
+     */
+    private $maxRequestsPerSec = 1;
+
+    /**
+     * @param string $timeKey
+     * LVN/shortcode when using the SMS or Voice API. Left as a blank string for the Developer API.
+     */
+    private $timeKey = '';
+
+    /**
+     * @param int $rate
+     */
+    public function setRate($rate)
+    {
+        $this->maxRequestsPerSec = $rate;
+    }
+
+    /**
+     * @param string $key
+     */
+    public function setKey($key)
+    {
+        $this->timeKey = $key;
+    }
+
+    /**
+     * @return array
+     */
+    public function getEvents()
+    {
+        return [
+            'before'   => ['onBefore'],
+            'complete' => ['onComplete'],
+        ];
+    }
+
+    /**
+     * @param BeforeEvent $event
+     */
+    public function onBefore(BeforeEvent $event)
+    {
+        self::$time[$this->timeKey] = microtime(true);
+        self::$counter[$this->timeKey] = isset(self::$counter[$this->timeKey]) ? self::$counter[$this->timeKey] + 1 : 1;
+    }
+
+    /**
+     * @param CompleteEvent $event
+     */
+    public function onComplete(CompleteEvent $event)
+    {
+        // Convert requests-per-second to a minimum duration in seconds.
+        $min_request_duration_sec = 1 / $this->maxRequestsPerSec;
+
+        // Calculate the duration of the previous request in seconds.
+        $elapsed_sec = microtime(true) - self::$time[$this->timeKey];
+
+        // If the duration is greater than the minimum duration, for this LVN, we must delay.
+        if ($elapsed_sec < $min_request_duration_sec) {
+            $min_request_duration_microsec = ($min_request_duration_sec - $elapsed_sec) * 1000000;
+            usleep($min_request_duration_microsec);
+        }
+    }
+}

--- a/src/Service/Account/Balance.php
+++ b/src/Service/Account/Balance.php
@@ -15,6 +15,15 @@ class Balance extends Service
     /**
      * @inheritdoc
      */
+    public function getRateLimit()
+    {
+        // Max number of requests per second. Nexmo developer API claims 3/sec max, but actually more than 2/sec causes error 429 Too Many Requests.
+        return 2;
+    }
+
+    /**
+     * @inheritdoc
+     */
     public function getEndpoint()
     {
         return 'account/get-balance';

--- a/src/Service/Account/Numbers.php
+++ b/src/Service/Account/Numbers.php
@@ -17,6 +17,15 @@ class Numbers extends Service
     /**
      * @inheritdoc
      */
+    public function getRateLimit()
+    {
+        // Max number of requests per second. Nexmo developer API claims 3/sec max, but actually more than 2/sec causes error 429 Too Many Requests.
+        return 2;
+    }
+
+    /**
+     * @inheritdoc
+     */
     public function getEndpoint()
     {
         return 'account/numbers';

--- a/src/Service/Account/Pricing/Country.php
+++ b/src/Service/Account/Pricing/Country.php
@@ -16,6 +16,15 @@ class Country extends Service
     /**
      * @inheritdoc
      */
+    public function getRateLimit()
+    {
+        // Max number of requests per second. Nexmo developer API permits 3/sec max.
+        return 2;
+    }
+
+    /**
+     * @inheritdoc
+     */
     public function getEndpoint()
     {
         return 'account/get-pricing/outbound';

--- a/src/Service/Account/Pricing/International.php
+++ b/src/Service/Account/Pricing/International.php
@@ -15,6 +15,15 @@ class International extends Country
     /**
      * @inheritdoc
      */
+    public function getRateLimit()
+    {
+        // Max number of requests per second. Nexmo developer API claims 3/sec max, but actually more than 2/sec causes error 429 Too Many Requests.
+        return 2;
+    }
+
+    /**
+     * @inheritdoc
+     */
     public function getEndpoint()
     {
         return 'account/get-prefix-pricing/outbound';

--- a/src/Service/Account/Pricing/Phone.php
+++ b/src/Service/Account/Pricing/Phone.php
@@ -14,6 +14,15 @@ use Nexmo\Service\Service;
 class Phone extends Service
 {
     /**
+     * @inheritdoc
+     */
+    public function getRateLimit()
+    {
+        // Max number of requests per second. Nexmo developer API claims 3/sec max, but actually more than 2/sec causes error 429 Too Many Requests.
+        return 2;
+    }
+
+    /**
      * @var string
      */
     protected $product;

--- a/src/Service/Message.php
+++ b/src/Service/Message.php
@@ -12,6 +12,20 @@ use Nexmo\Exception;
 class Message extends Service
 {
     /**
+     * @inheritdoc
+     */
+    public function getRateLimit($params = null)
+    {
+        if (preg_match('/^1\d{10}$/', $params['from']) && preg_match('/^1\d{10}$/', $params['to'])) {
+            // SMS from US/Canadian LVN to US/Canadian recipient has a 1/sec rate limit.
+            // https://help.nexmo.com/hc/en-us/articles/203993598
+            return 1;
+        }
+        // For all others, Nexmo Voice API has a 30/sec rate limit.
+        return 30;
+    }
+
+    /**
      * @return string
      */
     public function getEndpoint()

--- a/src/Service/ResourceCollection.php
+++ b/src/Service/ResourceCollection.php
@@ -39,6 +39,7 @@ abstract class ResourceCollection extends Resource
             }
             $cls = $this->initializeClass($clsName);
             $cls->setClient($this->client);
+            $cls->rateLimitSubscriber = new \Nexmo\RateLimitSubscriber();
 
             $this->resources[$name] = $cls;
         }

--- a/src/Service/Verify.php
+++ b/src/Service/Verify.php
@@ -12,6 +12,15 @@ use Nexmo\Exception;
 class Verify extends Service
 {
     /**
+     * @inheritdoc
+     */
+    public function getRateLimit()
+    {
+        // Max number of requests per second. Nexmo developer API claims 3/sec max, but actually more than 2/sec causes error 429 Too Many Requests.
+        return 2;
+    }
+
+    /**
      * @var VerifyCheck
      */
     public $check;

--- a/src/Service/VerifyCheck.php
+++ b/src/Service/VerifyCheck.php
@@ -10,6 +10,15 @@ use Nexmo\Exception;
  */
 class VerifyCheck extends Service
 {
+    /**
+     * @inheritdoc
+     */
+    public function getRateLimit()
+    {
+        // Max number of requests per second. Nexmo developer API claims 3/sec max, but actually more than 2/sec causes error 429 Too Many Requests.
+        return 2;
+    }
+
 
     /**
      * @return string

--- a/src/Service/Voice.php
+++ b/src/Service/Voice.php
@@ -11,6 +11,15 @@ use Nexmo\Exception;
 class Voice extends Service
 {
     /**
+     * @inheritdoc
+     */
+    public function getRateLimit()
+    {
+        // Max number of requests per second. Nexmo Voice API has a 30/sec rate limit.
+        return 30;
+    }
+
+    /**
      * @return string
      */
     public function getEndpoint()


### PR DESCRIPTION
Nexmo will reject requests if they are submitted too quickly with a "429 Too Many Requests" error. The limit for the Developer API is 3 requests per second, and the SMS and Voice APIs limit at 30 requests per second (except US/Canada, it's 1 request per second). Details at https://help.nexmo.com/hc/en-us/articles/203993598

This commit includes changes to use a RateLimitSubscriber, which is a native hook for the Guzzle HTTP client. It times the previous request, and if it is faster than the minimum to stay below the rate limit, it will sleep long enough so the second request does not violate the rate limit. SMS and Voice requests are timed on a per-LVN basis so the delay will only occur when sending from the same LVN too quickly would trigger the limit, but sending from different LVNs will still be fast. Each service class is given a getRateLimit() method which returns the limit for that specific API endpoint.
