### PR TITLE
Modify validation to work in edge cases

### DIFF
--- a/src/Service/Account/Numbers.php
+++ b/src/Service/Account/Numbers.php
@@ -51,6 +51,10 @@ class Numbers extends Service
         if (!isset($json['count'])) {
             throw new Exception('count property expected');
         }
+        if (0 == $json['count']) {
+            // If there are no numbers on the account, stop validating.
+            return;
+        }
         if (!isset($json['numbers']) || !is_array($json['numbers'])) {
             throw new Exception('numbers array property expected');
         }
@@ -66,9 +70,6 @@ class Numbers extends Service
             }
             if (!isset($number['features']) || !is_array($number['features'])) {
                 throw new Exception('number.features array property expected');
-            }
-            if (!isset($number['moHttpUrl'])) {
-                throw new Exception('number.moHttpUrl property expected');
             }
         }
     }

--- a/src/Service/Account/Pricing/Country.php
+++ b/src/Service/Account/Pricing/Country.php
@@ -34,7 +34,8 @@ class Country extends Service
         }
 
         return new Entity\Pricing($this->exec([
-            'country' => $country,
+            // Nexmo API requires $country value to be uppercase.
+            'country' => strtoupper($country),
         ]));
     }
 
@@ -43,6 +44,10 @@ class Country extends Service
      */
     protected function validateResponse(array $json)
     {
+        if (!isset($json['mt'])) {
+            // Some countries don't have any values, e.g., BV.
+            return;
+        }
         if (!isset($json['country'])) {
             throw new Exception('country property expected');
         }


### PR DESCRIPTION
Nexmo's API is inconsistent when dealing with edge cases. I've had to relax the validation to avoid throwing exceptions during perfectly valid API responses.
- In Account/Numbers.php, if the account has no numbers attached, the 'count' will be zero and further validation would fail. Here we just exit validation if the count is zero. 
- In Account/Numbers.php, the 'moHttpUrl' value may not exist if a number has been added without one (in which case the account's default moHttpUrl will be used). We cannot expect this value to exist.
- In Account/Pricing/Country.php the country parameter should always be uppercase (Nexmo will error if it is not). 
- In Account/Pricing/Country.php, some countries do not have a 'mt' price value set (e.g., BV) so we can't expect it.
