### PR TITLE
Fixed strict php errors during tests

### DIFF
--- a/tests/Service/Account/NumbersTest.php
+++ b/tests/Service/Account/NumbersTest.php
@@ -141,7 +141,7 @@ class NumbersMock extends Numbers
 {
     public $executedParams;
 
-    protected function exec($params)
+    protected function exec($params, $method = 'GET')
     {
         $this->executedParams = $params;
         return parent::exec($params);

--- a/tests/Service/Account/Pricing/CountryTest.php
+++ b/tests/Service/Account/Pricing/CountryTest.php
@@ -123,7 +123,7 @@ class CountryMock extends Country
 {
     public $executedParams;
 
-    protected function exec($params)
+    protected function exec($params, $method = 'GET')
     {
         $this->executedParams = $params;
         return parent::exec($params);

--- a/tests/Service/Account/Pricing/InternationalTest.php
+++ b/tests/Service/Account/Pricing/InternationalTest.php
@@ -96,7 +96,7 @@ class InternationalMock extends International
 {
     public $executedParams;
 
-    protected function exec($params)
+    protected function exec($params, $method = 'GET')
     {
         $this->executedParams = $params;
         return parent::exec($params);

--- a/tests/Service/Account/Pricing/PhoneTest.php
+++ b/tests/Service/Account/Pricing/PhoneTest.php
@@ -100,7 +100,7 @@ class PhoneMock extends Phone
 {
     public $executedParams;
 
-    protected function exec($params)
+    protected function exec($params, $method = 'GET')
     {
         $this->executedParams = $params;
         return parent::exec($params);

--- a/tests/Service/TestServiceTrait.php
+++ b/tests/Service/TestServiceTrait.php
@@ -11,7 +11,7 @@ trait TestServiceTrait
         return $this->validateResponse($params);
     }
 
-    protected function exec($params)
+    protected function exec($params, $method = 'GET')
     {
         $this->executedParams = $params;
     }


### PR DESCRIPTION
Travis reports a lot of php strict errors when running tests because of missing `$method` param on `exec()` method for several traits (e.g. see output of https://travis-ci.org/ConnectCorp/nexmo-client/jobs/79275172). This PR fixes it.
