### PR TITLE
Nexmo request parameter format change

### DIFF
--- a/src/Service/Message.php
+++ b/src/Service/Message.php
@@ -93,7 +93,7 @@ class Message extends Service
             'text' => $text,
             'status-report-req' => $statusReportReq,
             'client-ref' => $clientRef,
-            'networ-code' => $networkCode,
+            'network-code' => $networkCode,
             'vcard' => $vcard,
             'vcal' => $vcal,
             'ttl' => $ttl,

--- a/src/Service/Message.php
+++ b/src/Service/Message.php
@@ -91,13 +91,13 @@ class Message extends Service
             'to' => $to,
             'type' => $type,
             'text' => $text,
-            'status_report_req' => $statusReportReq,
-            'client_ref' => $clientRef,
-            'network_code' => $networkCode,
+            'status-report-req' => $statusReportReq,
+            'client-ref' => $clientRef,
+            'networ-code' => $networkCode,
             'vcard' => $vcard,
             'vcal' => $vcal,
             'ttl' => $ttl,
-            'message_class' => $messageClass,
+            'message-class' => $messageClass,
             'body' => $body,
             'udh' => $udh
         ]);

--- a/tests/Service/MessageTest.php
+++ b/tests/Service/MessageTest.php
@@ -26,13 +26,13 @@ class MessageTest extends TestCase
             'to' => 5005551111,
             'type' => 'text',
             'text' => 'message',
-            'status_report_req' => 'status_rep_req',
-            'client_ref' => 'client_ref',
-            'network_code' => 'net_code',
+            'status-report-req' => 'status_rep_req',
+            'client-ref' => 'client_ref',
+            'network-code' => 'net_code',
             'vcard' => 'vcard',
             'vcal' => 'vcal',
             'ttl' => 1,
-            'message_class' => 'class',
+            'message-class' => 'class',
             'body' => 'body',
             'udh' => 'udh'
         ]);


### PR DESCRIPTION
Nexmo API has changed the Request parameter formatting from underscore concatenation to hyphen concatenation. Parameter formattin changed accordingly:

When sending SMSs the request parameters are concatenated with underscore:
https://github.com/ConnectCorp/nexmo-client/blob/master/src/Service/Message.php#L96

but Nexmo API says that they should be hyphenated:
https://docs.nexmo.com/api-ref/sms-api/request
